### PR TITLE
🪗  changed roadmap configuration to only one init to prevent too much…

### DIFF
--- a/Sources/Roadmap/DataProviders/FeaturesFetcher.swift
+++ b/Sources/Roadmap/DataProviders/FeaturesFetcher.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 struct FeaturesFetcher {
-    let featureJSONURL: URL
+    let featureRequest: URLRequest
 
     func fetch() async -> [RoadmapFeature] {
         do {
-            return try await JSONDataFetcher.loadJSON(url: featureJSONURL)
+            return try await JSONDataFetcher.loadJSON(request: featureRequest)
         } catch {
             print("error:", error.localizedDescription)
             return []

--- a/Sources/Roadmap/DataProviders/JSONDataFetcher.swift
+++ b/Sources/Roadmap/DataProviders/JSONDataFetcher.swift
@@ -21,6 +21,11 @@ struct JSONDataFetcher {
         return try JSONDecoder().decode(T.self, from: data)
     }
 
+    static func loadJSON<T: Decodable>(request: URLRequest) async throws -> T {
+        let data = try await urlSession.data(for: request).0
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+    
     static func loadJSON<T: Decodable>(fromURLString urlString: String) async throws -> T {
         guard let url = URL(string: urlString) else {
             throw Error.invalidURL

--- a/Sources/Roadmap/RoadmapFeatureView.swift
+++ b/Sources/Roadmap/RoadmapFeatureView.swift
@@ -109,6 +109,6 @@ struct RoadmapFeatureView: View {
 
 struct RoadmapFeatureView_Previews: PreviewProvider {
     static var previews: some View {
-        RoadmapFeatureView(viewModel: .init(feature: .sample(), configuration: .sample()))
+        RoadmapFeatureView(viewModel: .init(feature: .sample(), configuration: .sampleURL()))
     }
 }

--- a/Sources/Roadmap/RoadmapView.swift
+++ b/Sources/Roadmap/RoadmapView.swift
@@ -58,6 +58,6 @@ public extension RoadmapView where Header: View, Footer: View {
 
 struct RoadmapView_Previews: PreviewProvider {
     static var previews: some View {
-        RoadmapView(configuration: .sample())
+        RoadmapView(configuration: .sampleURL())
     }
 }

--- a/Sources/Roadmap/RoadmapViewModel.swift
+++ b/Sources/Roadmap/RoadmapViewModel.swift
@@ -28,15 +28,17 @@ final class RoadmapViewModel: ObservableObject {
     init(configuration: RoadmapConfiguration) {
         self.configuration = configuration
         self.allowSearching = configuration.allowSearching
-        loadFeatures(roadmapJSONURL: configuration.roadmapJSONURL)
+
+        loadFeatures(request: configuration.roadmapRequest)
     }
 
-    func loadFeatures(roadmapJSONURL: URL) {
+    func loadFeatures(request: URLRequest) {
+        
         Task { @MainActor in
             if configuration.shuffledOrder {
-                self.features = await FeaturesFetcher(featureJSONURL: roadmapJSONURL).fetch().shuffled()
+                self.features = await FeaturesFetcher(featureRequest: request).fetch().shuffled()
             } else {
-                self.features = await FeaturesFetcher(featureJSONURL: roadmapJSONURL).fetch()
+                self.features = await FeaturesFetcher(featureRequest: request).fetch()
             }
         }
     }


### PR DESCRIPTION
🪗 changed roadmap configuration to only one init to prevent too much overhead over time
✍️ the roadmap configuration only holds an URLRequest, simple URL is used only as parameter
✍️ changed fetcher to work with URLRequest instead of just URL